### PR TITLE
Fix deadlock by closing pipe on exit

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -776,7 +776,7 @@ create_pool()
 		int jobs = envfd("JOBS");
 		if (jobs > 1) {
 			int i, fds[2];
-			pipe(fds);
+			pipe2(fds, O_CLOEXEC);
 			poolrd_fd = fds[0];
 			poolwr_fd = fds[1];
 


### PR DESCRIPTION
In 1 of 1000000 cases redo-ifchange gets blocked at a read call
in function try_procure (line 752 in redo.c) and the child process
ends in zombie state.
An additional usleep call before the read call causes this effect to
occur more often.

I do not know why, but closing the pipe during exit fixes this issue.