### PR TITLE
Fix non implicit job lease detection

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -816,10 +816,11 @@ redo_ifchange(int targetc, char *targetv[])
 				continue;
 			}
 
+			int implicit = implicit_jobs > 0;
 			if (try_procure()) {
 				procured = 1;
 				targeti++;
-				run_script(target, implicit_jobs >= 0);
+				run_script(target, implicit);
 			}
 		}
 


### PR DESCRIPTION
If a job is non implicit, the job lease will never be written back via
function vacate. The information non implicit is wrongly derived by the
counter implicit_jobs, which will never be negative and therefor
run_script is always called with implicit job true.

This fix checks if implicit is possible before procuring the job lease.