### PR TITLE
sourcefile() : adding find_dofile() == 0 test in case of forced redo.

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -337,7 +337,7 @@ datefile(int fd)
 	struct stat st;
 
 	fstat(fd, &st);
-	snprintf(hexdate, sizeof hexdate, "%016" PRIx64, st.st_ctime);
+	snprintf(hexdate, sizeof hexdate, "%016" PRIx64, (int64_t) st.st_ctime);
 
 	return hexdate;
 }

--- a/redo.c
+++ b/redo.c
@@ -398,11 +398,14 @@ static int
 sourcefile(char *target)
 {
 	target = targetchdir(target);
-	
-	if ( fflag > 0 )
-		return ( find_dofile ( target ) == 0 );
-	
-	return access(target, F_OK) == 0 && access(targetdep(target), F_OK) != 0;
+
+	if (access(targetdep(target), F_OK) == 0)
+		return 0;
+
+	if ( fflag < 0 )
+		return (access(target, F_OK) == 0);
+
+	return (find_dofile(target) == 0);
 }
 
 static int

--- a/redo.c
+++ b/redo.c
@@ -398,6 +398,10 @@ static int
 sourcefile(char *target)
 {
 	target = targetchdir(target);
+	
+	if ( fflag > 0 )
+		return ( find_dofile ( target ) == 0 );
+	
 	return access(target, F_OK) == 0 && access(targetdep(target), F_OK) != 0;
 }
 
@@ -970,7 +974,7 @@ main(int argc, char *argv[])
 	dir_fd = keepdir();
 
 	if (strcmp(program, "redo") == 0) {
-		fflag = 1;
+		// fflag = 1;
 		redo_ifchange(argc, argv);
 		procure();
 	} else if (strcmp(program, "redo-ifchange") == 0) {

--- a/redo.c
+++ b/redo.c
@@ -974,7 +974,7 @@ main(int argc, char *argv[])
 	dir_fd = keepdir();
 
 	if (strcmp(program, "redo") == 0) {
-		// fflag = 1;
+		fflag = 1;
 		redo_ifchange(argc, argv);
 		procure();
 	} else if (strcmp(program, "redo-ifchange") == 0) {


### PR DESCRIPTION
Deleting .dep file of some target makes redo thinking of it as the source. This can be used for blocking some subtree rebuilding. Excluded subtree will be involved into the normal build process after "redo -f".