### PR TITLE
Specify starting point for 'find'

### DIFF
--- a/redo-sources
+++ b/redo-sources
@@ -1,7 +1,7 @@
 #!/bin/sh
 # redo-sources - list dependencies which are not targets
 
-find -name '.dep.*' | xargs grep -h '^=' | cut -c84- |
+find . -name '.dep.*' | xargs grep -h '^=' | cut -c84- |
 while read f; do
 	[ -e "$f" ] &&
 	! [ -e "$(printf '%s' "$f" | sed 's,\(.*/\)\|,\1.dep.,')" ] &&

--- a/redo-targets
+++ b/redo-targets
@@ -1,4 +1,4 @@
 #!/bin/sh
 # redo-targets - list files redo can build
 
-find -name '.dep.*' | sed 's,\(.*\)/\.dep\.,\1/,' | sort
+find . -name '.dep.*' | sed 's,\(.*\)/\.dep\.,\1/,' | sort


### PR DESCRIPTION
non-GNU versions of find (e.g. BSD) do not allow omitting the
starting point.