### PR TITLE
Fix some compiler warnings

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -337,7 +337,7 @@ datefile(int fd)
 	struct stat st;
 
 	fstat(fd, &st);
-	snprintf(hexdate, sizeof hexdate, "%016" PRIx64, st.st_ctime);
+	snprintf(hexdate, sizeof hexdate, "%016" PRIx64, (uint64_t)st.st_ctime);
 
 	return hexdate;
 }
@@ -662,9 +662,9 @@ run_script(char *target, int implicit)
 		dirprefix++;
 
 	snprintf(temp_target, sizeof temp_target,
-	    "%s%s%s", dirprefix, "/"+(*dirprefix ? 0 : 1), temp_target_base);
+	    "%s%s%s", dirprefix, (*dirprefix ? "/" : ""), temp_target_base);
 	snprintf(rel_target, sizeof rel_target,
-	    "%s%s%s", dirprefix, "/"+(*dirprefix ? 0 : 1), target);
+	    "%s%s%s", dirprefix, (*dirprefix ? "/" : ""), target);
 
 	if (dirprefix)
 		setenv("REDO_DIRPREFIX", dirprefix, 1);


### PR DESCRIPTION
On non-Linux systems (e.g. macOS, BSD), st.st_ctime may not be
of the right type for PRIx64 ; so just cast it to an uint64_t,
which is the type PRIx64 corresponds to.

Also, clang may warn about `"/"+(*dirprefix ? 0 : 1)`, suspecting
a coding error. Using `(*dirprefix ? "/" : "")` is unambiguous and
also easier to grok for some people (e.g. myself ;-)).