### PR TITLE
change fflag testing from ! to < 0

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -402,7 +402,7 @@ sourcefile(char *target)
 	if (access(targetdep(target), F_OK) == 0)
 		return 0;
 
-	if (!fflag)
+	if (fflag < 0)
 		return access(target, F_OK) == 0;
 
 	return find_dofile(target) == 0;


### PR DESCRIPTION
fflag can not tbe assigned 0 value, because envfd() may return only 1 or -1. This means that !fflag will never give "true" and find_dofile() will be called even if it is not necessary..