### PR TITLE
Calling compute_uprel() before redo_ifchange()

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -901,7 +901,6 @@ record_deps(int targetc, char *targetv[])
 		return;
 
 	fchdir(dir_fd);
-	compute_uprel();
 
 	for (targeti = 0; targeti < targetc; targeti++) {
 		fd = open(targetv[targeti], O_RDONLY);
@@ -981,6 +980,7 @@ main(int argc, char *argv[])
 		redo_ifchange(argc, argv);
 		procure();
 	} else if (strcmp(program, "redo-ifchange") == 0) {
+		compute_uprel();
 		redo_ifchange(argc, argv);
 		record_deps(argc, argv);
 		procure();


### PR DESCRIPTION
record_deps() is called after redo_ifchange(). It needs uprel[] value
corresponding to REDO_DIRPREFIX supplied by the parent process. But
redo_ifchange() may modify REDO_DIRPREFIX in case it will envoke default*.do
file located in one of updirs. In this case if compute_uprel() will be
called from inside record_deps(), it will produce wrong uprel[] value.
That's why compute_uprel() must be called before run_script() will be
able to change REDO_DIRPREFIX for the child process.