### PR TITLE
Default target "all" available for "redo" only

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -968,9 +968,10 @@ main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
-	if (argc == 0) {
+	if ((argc == 0) && (strcmp(program, "redo") == 0)) {
+		char *argv_def[] = {(char *) "all"};
 		argc = 1;
-		argv[0] = (char *)"all";    // XXX safe?
+		argv = argv_def;
 	}
 
 	dir_fd = keepdir();


### PR DESCRIPTION
Seems, that for "redo-ifchange" and "redo-ifcreate" default "all"
target don't make much sense. Initializing default target in a
safer manner.