### PR TITLE
Intialise dep_fd earlier to write negative dependencies correctly

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -31,6 +31,7 @@ todo:
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -199,6 +200,47 @@ redo_ifcreate(int fd, char *target)
 {
 	dprintf(fd, "-%s\n", target);
 }
+
+static int
+check_tempfile(char *fname) {
+  return strlen(name == 14)
+           && (strncmp(name, ".depend", 7) == 0 || strncmp(name, ".target", 7) == 0);
+}
+
+// TODO: Better exits (return is useless)
+// TODO: actually call this function
+static int
+cleanup(char *path)
+{
+      DIR *d;
+      struct dirent *entry;
+      struct stat entrystat;
+      char entrypath[PATH_MAX];
+
+      d = opendir(path);
+      if(!d)
+	    return 1; 
+
+      strcpy(entrypath, path);
+      strcat(entrypath, "/");
+      size_t baselen = strlen(entrypath);
+
+      while ((entry=readdir(d))) {
+	    stat(entry->d_name, &entrystat);
+	    entrypath[baselen] = 0;
+	    strcat(entrypath, entry->d_name);
+	    
+	    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, ".."))
+	          continue;
+
+	    if (S_ISDIR(entrystat.st_mode))
+	      cleanup(entrypath);
+
+	    if (check_tempfile(entry->d_name)
+		  remove(entrypath);
+      }
+}
+
 
 static char *
 check_dofile(const char *fmt, ...)
@@ -902,7 +944,7 @@ record_deps(int targetc, char *targetv[])
 	fchdir(dir_fd);
 
 	for (targeti = 0; targeti < targetc; targeti++)
-		write_dep(dep_fd, targetv[targeti]);
+   		write_dep(dep_fd, targetv[targeti]);
 }
 
 int

--- a/redo.c
+++ b/redo.c
@@ -629,6 +629,7 @@ run_script(char *target, int implicit)
 	pid_t pid;
 
 	target = targetchdir(target);
+	dep_fd = mkstemp(temp_depfile);
 
 	dofile = find_dofile(target);
 	if (!dofile) {
@@ -649,8 +650,6 @@ run_script(char *target, int implicit)
 			exit(111);
 		}
 	}
-
-	dep_fd = mkstemp(temp_depfile);
 
 	target_fd = mkstemp(temp_target_base);
 


### PR DESCRIPTION
During the execution of `find_dofile` we need to write to the dependency file; at least if a dofile is not found in the current directory. This is what `redo_ifcreate` called by `check_dofile` does.

However, the dependency file descriptor `dep_fd` is initiated _after_ `find_dofile` is called.

As a result, the `dep_fd` for the first target is `-1`, so there are no negative dependencies to dofiles. Moreover, the negative dependencies are written to the `dep_fd` of the previous target. This behaviour is especially problematic, when writing the negative dependencies for the first target of a new subdirectory.

If you wish to reproduce this behaviour, you may use my dummy project: https://github.com/lions-tech/redo-c-testproj