### PR TITLE
Fix Issue #25: Prevent creation of virtual targets

### DIFF
--- a/redo.c
+++ b/redo.c
@@ -868,6 +868,9 @@ redo_ifchange(int targetc, char *targetv[])
 				if (stat(job->temp_target, &st) == 0) {
 					rename(job->temp_target, target);
 					write_dep(dfd, target);
+
+					if (st.st_size > 1)
+						remove(target);
 				} else {
 					remove(job->temp_target);
 					redo_ifcreate(dfd, target);


### PR DESCRIPTION
This small PR fixes issue #25 by simply deleting the target.

This change fully complies to the feature advertised in the README.md: "When a target makes no output, no target file is created. The target is considered always out of date."

Deleting the target after it has been renamed and written as dependency for itself, causes the target to always be considered out of date.

This PR can be tested using my test project: https://github.com/lions-tech/redo-c-testproj

What do you think about this?